### PR TITLE
Add support for interface{} JSON instead of just map[string]interface{}

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -9,15 +9,15 @@ type APITest struct {
 }
 
 type APIRequest struct {
-	Body        string                 `json:"body"`
-	Headers     map[string]string      `json:"headers"`
-	JSON        map[string]interface{} `json:"json"`
-	QueryParams map[string]string      `json:"query-params"`
+	Body        string            `json:"body"`
+	Headers     map[string]string `json:"headers"`
+	JSON        interface{}       `json:"json"`
+	QueryParams map[string]string `json:"query-params"`
 }
 
 type APIResponse struct {
-	Body       string                 `json:"body"`
-	Headers    map[string]string      `json:"headers"`
-	JSON       map[string]interface{} `json:"json"`
-	StatusCode int                    `json:"code"`
+	Body       string            `json:"body"`
+	Headers    map[string]string `json:"headers"`
+	JSON       interface{}       `json:"json"`
+	StatusCode int               `json:"code"`
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -30,13 +30,13 @@ func TestAssertJSON(t *testing.T) {
 	var actual map[string]interface{}
 
 	// Both maps nil should result in nil error
-	if assertJSON(actual, expected) != nil {
+	if !assertJSON(actual, expected) {
 		t.Errorf("Received unexpected error when asserting json of nil maps")
 	}
 
 	// Only expected nil should result in nil error
 	expected = make(map[string]interface{})
-	if assertJSON(actual, expected) != nil {
+	if !assertJSON(actual, expected) {
 		t.Errorf("Received unexpected error when asserting json of nil maps")
 	}
 
@@ -45,7 +45,7 @@ func TestAssertJSON(t *testing.T) {
 	}
 
 	// The exact same data should result in no error
-	if assertJSON(expected, expected) != nil {
+	if !assertJSON(expected, expected) {
 		t.Errorf("Received unexpected error when asserting json of matching maps")
 	}
 
@@ -54,7 +54,7 @@ func TestAssertJSON(t *testing.T) {
 	}
 
 	// Mismatching values should fail
-	if assertJSON(actual, expected) == nil {
+	if assertJSON(actual, expected) {
 		t.Errorf("Expected to receive error when comparing mismatching maps")
 	}
 }


### PR DESCRIPTION
There are some API responses and requests that could simply contain a body like `34` or `false`, not necessarily a map.